### PR TITLE
Update WW3 submodule and related changes

### DIFF
--- a/components/ww3/cime_config/buildlib_cmake
+++ b/components/ww3/cime_config/buildlib_cmake
@@ -78,15 +78,18 @@ def buildlib(bldroot, installpath, case):
 y
 """.format(sf90, scc, tmpdir))
 
-    run_bld_cmd_ensure_logging("./w3_setup {} -c {} -s E3SM < w3_setup.inp".format(modeldir, comp), logger, from_dir=bindir)
+    run_bld_cmd_ensure_logging("./w3_setup {} -s E3SM < w3_setup.inp".format(modeldir), logger, from_dir=bindir)
     os.remove(inp_file)
     os.remove(os.path.join(bindir, "switch_E3SM"))
 
     # Generate pre-processed WW3 source code
-    tarfile = "{}/work/ww3_shel.tar.gz".format(modeldir)
-    run_bld_cmd_ensure_logging("./w3_source ww3_shel", logger, from_dir=bindir)
-    shutil.move(tarfile, tmpdir)
-    run_bld_cmd_ensure_logging("tar -xzvf ww3_shel.tar.gz", logger, from_dir=tmpdir)
+    ww3_exe = ['ww3_shel','ww3_grid']
+    for exe in ww3_exe:
+      run_bld_cmd_ensure_logging("./w3_source {}".format(exe), logger, from_dir=bindir)
+    for exe in ww3_exe:
+      tarfile = "{}/work/{}.tar.gz".format(modeldir,exe)
+      shutil.move(tarfile, tmpdir)
+      run_bld_cmd_ensure_logging("tar -xzvf {}.tar.gz".format(exe), logger, from_dir=tmpdir)
 
     with open(os.path.join(casebuild, "ww3conf", "Filepath"), "w") as fd:
         fd.write(


### PR DESCRIPTION
 - E3SM WW3 branch has been rebased on most recent NOAA-EMC develop branch
   (fc3576f413acfe44f4c81e95eefd8ff7b5b21cdd)

   On top of this there are two important modifications:

     1) Fixes for rotated global unstructured meshes
     2) Re-organization of ww3_grid code into new module and subroutine

 - wav_comp_mct.F90 has been modified to update the interfaces to w3init
   and w3wave from the develop branch.

 - buildlib_cmake has be updated for the develop branch, w3_setup no
   longer uses the -c argument

 - buildlib_cmake now runs w3_source on the ww3_grid target to generate
   source code for the  w3gridmd module used to call w3grid from within
   wav_comp_init

 -  The wave_comp_init subroutine in wave_comp_mct.F was modified to
    call w3grid to generate the mod_def.ww3 and other related files
    prior to running the wave model. This is done serially.